### PR TITLE
Make home:ro by setting the path conf dir

### DIFF
--- a/org.recoll.recoll.yml
+++ b/org.recoll.recoll.yml
@@ -16,7 +16,8 @@ finish-args:
   - --socket=fallback-x11
   - --socket=wayland
   - --device=dri
-  - --filesystem=home
+  - --filesystem=home:ro
+  - --env=RECOLL_CONFDIR=.var/app/org.recoll.recoll/
   - --env=ASPELL_CONF=dict-dir /app/share/dicts; local-data-dir /app/share/datadicts
   - --env=ANTIWORDHOME=/app/share/antiword
   - --env=JUPYTER_DATA_DIR=/app/share/jupyter


### PR DESCRIPTION
Sets RECOLL_CONFDIR to the flatpak app space meaning home can be readonly.